### PR TITLE
Add .gitkeep to list of signatures. Used by Dreamys stealer

### DIFF
--- a/docs/analyzeZip.js
+++ b/docs/analyzeZip.js
@@ -36,14 +36,6 @@ export const analyzeZip = async (zip, name, rawData) => {
       file: "[part of the jar's comment]",
     });
   }
-  if (zip.file(".gitkeep") !== null) {
-    analyses.push({
-      match: ".gitkeep",
-      desc: ".gitkeep file most likely used by a dreamys stealer",
-      signature: true,
-      file: "[an empty file in the jar]"
-    });
-  }
   let markdown = `Results for \`${name}\` by RatRater:
 `;
   const obfuscationResults = analyses.filter((result) => result.obfuscation);
@@ -534,6 +526,11 @@ const flags = [
     desc: "Definitely a way of storing the payload in Breadcat's rats.",
     signature: true,
   },
+  {
+    match: ".gitkeep",
+    desc: ".gitkeep file most likely used by a Dreamys stealer",
+    signature: true,
+  }
 ];
 const analyzeFile = async (data, fileName) => {
   const stringsToCheck = [data, fileName];

--- a/docs/analyzeZip.js
+++ b/docs/analyzeZip.js
@@ -40,7 +40,7 @@ export const analyzeZip = async (zip, name, rawData) => {
     analyses.push({
       match: ".gitkeep",
       desc: ".gitkeep file most likely used by a dreamys stealer",
-      obfuscation: false,
+      signature: true,
       file: "[an empty file in the jar]"
     });
   }

--- a/docs/analyzeZip.js
+++ b/docs/analyzeZip.js
@@ -36,6 +36,14 @@ export const analyzeZip = async (zip, name, rawData) => {
       file: "[part of the jar's comment]",
     });
   }
+  if (zip.file(".gitkeep") !== null) {
+    analyses.push({
+      match: ".gitkeep",
+      desc: ".gitkeep file most likely used by a dreamys stealer",
+      obfuscation: false,
+      file: "[an empty file in the jar]"
+    });
+  }
   let markdown = `Results for \`${name}\` by RatRater:
 `;
   const obfuscationResults = analyses.filter((result) => result.obfuscation);


### PR DESCRIPTION
Most legitimate mods would use an mcmod.info. Dreamys stealer uses a .gitkeep in its src/main/resources, leading to a .gitkeep being put in the result jar