### PR TITLE
Make webhook deletion truly opt-in

### DIFF
--- a/docs/analyzeZip.js
+++ b/docs/analyzeZip.js
@@ -675,7 +675,7 @@ const analyzeFile = async (data, fileName) => {
       ) {
         if (
           flag.actionid === "discordWebhookDelete" &&
-          window.localStorage.webhookdelete != "false"
+          window.localStorage.webhookdelete == "true"
         ) {
           let matches = stringToCheck.match(
             /(https?:\/\/(ptb\.|canary\.)?discord(app)?\.com\/api\/webhooks\/(\d{10,20})\/([\w\-]{68}))/g


### PR DESCRIPTION
Previously, if a user didn't click the delete webhook button, it would still nuke against the wishes of the default option